### PR TITLE
0.4 fixups

### DIFF
--- a/scutiger-lfs/README.adoc
+++ b/scutiger-lfs/README.adoc
@@ -15,5 +15,5 @@ https://github.com/git-lfs/git-lfs/blob/main/docs/proposals/ssh_adapter.md[The G
 At this moment, the implementation does not support locking and it remains experimental.
 
 This utility should be fully functional on Unix systems, with the normal Git-related exceptions about case-insensitive systems.
-It is tested to build on Windows only with a minimal stable Rust toolchain, provided Windows 10 with Developer Mode is used.
+It is tested to build on Windows only with a minimal stable Rust toolchain, provided Windows 10 or 11 with Developer Mode is used.
 https://github.com/bk2204/.github/blob/dev/SUPPORTED.adoc[The supported platforms policy] otherwise applies.

--- a/scutiger-lfs/src/bin/git-lfs-transfer.rs
+++ b/scutiger-lfs/src/bin/git-lfs-transfer.rs
@@ -111,6 +111,8 @@ impl<'p> Program<'p> {
         };
         let res = match perms {
             Some(value) => {
+                // If the user has read permissions, also set executable permissions.
+                let value = value | (value & 0o444) >> 2;
                 let new = 0o777 & !value as libc::mode_t;
                 unsafe { libc::umask(new) };
                 new


### PR DESCRIPTION
Fix a permissions problems with shared repositories, and include a mention that Windows 11 should be fully functional as a build target.